### PR TITLE
Postpone build script misconfiguration at task execution

### DIFF
--- a/gradle-plugin/src/main/kotlin/io/github/manriif/supabase/functions/Constants.kt
+++ b/gradle-plugin/src/main/kotlin/io/github/manriif/supabase/functions/Constants.kt
@@ -31,6 +31,7 @@ internal const val COROUTINES_VERSION_GRADLE_PROPERTY = "supabase.functions.coro
 internal const val DENO_KOTLIN_BRIDGE_FUNCTION_NAME = "denoKotlinBridge"
 internal const val KOTLIN_MAIN_FUNCTION_NAME = "serve"
 
+internal const val IMPORT_MAPS_DIRECTORY_NAME = "importMaps"
 internal const val GITIGNORE_FILE_NAME = ".gitignore"
 internal const val IMPORT_MAP_TEMPLATE_FILE_NAME = "import_map_template.json"
 internal const val IMPORT_MAP_FILE_NAME = "import_map.json"

--- a/gradle-plugin/src/main/kotlin/io/github/manriif/supabase/functions/Constants.kt
+++ b/gradle-plugin/src/main/kotlin/io/github/manriif/supabase/functions/Constants.kt
@@ -31,7 +31,6 @@ internal const val COROUTINES_VERSION_GRADLE_PROPERTY = "supabase.functions.coro
 internal const val DENO_KOTLIN_BRIDGE_FUNCTION_NAME = "denoKotlinBridge"
 internal const val KOTLIN_MAIN_FUNCTION_NAME = "serve"
 
-internal const val IMPORT_MAPS_DIRECTORY_NAME = "importMaps"
 internal const val GITIGNORE_FILE_NAME = ".gitignore"
 internal const val IMPORT_MAP_TEMPLATE_FILE_NAME = "import_map_template.json"
 internal const val IMPORT_MAP_FILE_NAME = "import_map.json"

--- a/gradle-plugin/src/main/kotlin/io/github/manriif/supabase/functions/SupabaseFunctionExtension.kt
+++ b/gradle-plugin/src/main/kotlin/io/github/manriif/supabase/functions/SupabaseFunctionExtension.kt
@@ -101,4 +101,8 @@ internal fun SupabaseFunctionExtension.setupConvention(project: Project) {
     functionName.convention(project.name)
     verifyJwt.convention(true)
     importMap.convention(true)
+
+    packageName.convention(project.provider {
+        error("packageName is not set, please provide the package name of the kotlin main function.")
+    })
 }

--- a/gradle-plugin/src/main/kotlin/io/github/manriif/supabase/functions/task/SupabaseFunctionAggregateImportMapTask.kt
+++ b/gradle-plugin/src/main/kotlin/io/github/manriif/supabase/functions/task/SupabaseFunctionAggregateImportMapTask.kt
@@ -28,12 +28,12 @@ import io.github.manriif.supabase.functions.IMPORT_MAP_TEMPLATE_FILE_NAME
 import io.github.manriif.supabase.functions.error.SupabaseFunctionImportMapTemplateException
 import io.github.manriif.supabase.functions.supabase.supabaseAllFunctionsDirFile
 import org.gradle.api.DefaultTask
+import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.tasks.CacheableTask
-import org.gradle.api.tasks.IgnoreEmptyDirectories
-import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputFile
@@ -51,10 +51,9 @@ import java.io.File
 @CacheableTask
 abstract class SupabaseFunctionAggregateImportMapTask : DefaultTask() {
 
-    @get:InputDirectory
-    @get:IgnoreEmptyDirectories
+    @get:InputFiles
     @get:PathSensitive(PathSensitivity.RELATIVE)
-    internal abstract val importMapsDir: DirectoryProperty
+    internal abstract val importMapDirs: ConfigurableFileCollection
 
     @get:Internal
     internal abstract val supabaseDir: DirectoryProperty
@@ -100,7 +99,7 @@ abstract class SupabaseFunctionAggregateImportMapTask : DefaultTask() {
         val imports = importMap.getAsJsonObject(IMPORT_MAP_JSON_IMPORTS)
         val scopes = importMap.getAsJsonObject(IMPORT_MAP_JSON_SCOPES)
 
-        importMapsDir.get().asFileTree
+        importMapDirs.asFileTree
             .matching {
                 include { file ->
                     !file.isDirectory && file.name.endsWith(".json")

--- a/gradle-plugin/src/main/kotlin/io/github/manriif/supabase/functions/task/SupabaseFunctionAggregateImportMapTask.kt
+++ b/gradle-plugin/src/main/kotlin/io/github/manriif/supabase/functions/task/SupabaseFunctionAggregateImportMapTask.kt
@@ -29,11 +29,13 @@ import io.github.manriif.supabase.functions.error.SupabaseFunctionImportMapTempl
 import io.github.manriif.supabase.functions.supabase.supabaseAllFunctionsDirFile
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.IgnoreEmptyDirectories
 import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
@@ -58,9 +60,9 @@ abstract class SupabaseFunctionAggregateImportMapTask : DefaultTask() {
     internal abstract val supabaseDir: DirectoryProperty
 
     @get:InputFile
+    @get:Optional
     @get:PathSensitive(PathSensitivity.RELATIVE)
-    internal val importMapTemplateFile: File
-        get() = supabaseAllFunctionsDirFile(supabaseDir, IMPORT_MAP_TEMPLATE_FILE_NAME)
+    internal abstract val importMapTemplateFile: RegularFileProperty
 
     @get:OutputFile
     internal val aggregatedImportMapFile: File
@@ -72,9 +74,11 @@ abstract class SupabaseFunctionAggregateImportMapTask : DefaultTask() {
             .setPrettyPrinting()
             .create()
 
-        val importMap = if (importMapTemplateFile.exists() && importMapTemplateFile.isFile) {
+        val template = importMapTemplateFile.orNull?.asFile
+
+        val importMap = if (template?.exists() == true && template.isFile) {
             try {
-                JsonParser.parseReader(importMapTemplateFile.reader()).asJsonObject
+                JsonParser.parseReader(template.reader()).asJsonObject
             } catch (throwable: Throwable) {
                 throw SupabaseFunctionImportMapTemplateException(
                     message = "Failed to load $IMPORT_MAP_TEMPLATE_FILE_NAME",

--- a/gradle-plugin/src/main/kotlin/io/github/manriif/supabase/functions/task/SupabaseFunctionCopyJsTask.kt
+++ b/gradle-plugin/src/main/kotlin/io/github/manriif/supabase/functions/task/SupabaseFunctionCopyJsTask.kt
@@ -40,7 +40,7 @@ import java.io.File
 import javax.inject.Inject
 
 /**
- * Task responsible for copying generated js code into supabase function directory.
+ * Task responsible for copying js sources into supabase function directory.
  */
 @CacheableTask
 abstract class SupabaseFunctionCopyJsTask : DefaultTask() {

--- a/gradle-plugin/src/main/kotlin/io/github/manriif/supabase/functions/task/SupabaseFunctionCopyKotlinTask.kt
+++ b/gradle-plugin/src/main/kotlin/io/github/manriif/supabase/functions/task/SupabaseFunctionCopyKotlinTask.kt
@@ -53,7 +53,6 @@ abstract class SupabaseFunctionCopyKotlinTask : DefaultTask() {
     internal abstract val supabaseDir: DirectoryProperty
 
     @get:InputDirectory
-    @get:Optional
     @get:PathSensitive(PathSensitivity.RELATIVE)
     internal abstract val compiledSourceDir: DirectoryProperty
 

--- a/gradle-plugin/src/main/kotlin/io/github/manriif/supabase/functions/task/SupabaseFunctionCopyKotlinTask.kt
+++ b/gradle-plugin/src/main/kotlin/io/github/manriif/supabase/functions/task/SupabaseFunctionCopyKotlinTask.kt
@@ -32,6 +32,7 @@ import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
@@ -52,6 +53,7 @@ abstract class SupabaseFunctionCopyKotlinTask : DefaultTask() {
     internal abstract val supabaseDir: DirectoryProperty
 
     @get:InputDirectory
+    @get:Optional
     @get:PathSensitive(PathSensitivity.RELATIVE)
     internal abstract val compiledSourceDir: DirectoryProperty
 

--- a/gradle-plugin/src/main/kotlin/io/github/manriif/supabase/functions/task/SupabaseFunctionGenerateImportMapTask.kt
+++ b/gradle-plugin/src/main/kotlin/io/github/manriif/supabase/functions/task/SupabaseFunctionGenerateImportMapTask.kt
@@ -29,13 +29,15 @@ import io.github.manriif.supabase.functions.JS_SOURCES_INPUT_DIR
 import io.github.manriif.supabase.functions.kmp.JsDependency
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Input
-import org.gradle.api.tasks.InputDirectory
+import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Nested
+import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
@@ -64,9 +66,10 @@ abstract class SupabaseFunctionGenerateImportMapTask : DefaultTask() {
     @get:Internal
     internal abstract val importMapsDir: DirectoryProperty
 
-    @get:InputDirectory
+    @get:InputFile
+    @get:Optional
     @get:PathSensitive(PathSensitivity.RELATIVE)
-    internal abstract val packageJsonDir: DirectoryProperty
+    internal abstract val packageJsonFile: RegularFileProperty
 
     @get:Input
     internal abstract val functionName: Property<String>
@@ -94,8 +97,7 @@ abstract class SupabaseFunctionGenerateImportMapTask : DefaultTask() {
 
     private fun createFunctionImports(): JsonObject {
         val imports = JsonObject()
-        val packageJsonFile = packageJsonDir.file("package.json").get().asFile
-        val packageJson = fromSrcPackageJson(packageJsonFile) ?: return imports
+        val packageJson = fromSrcPackageJson(packageJsonFile.orNull?.asFile) ?: return imports
 
         packageJson.dependencies.forEach { (packageName, version) ->
             imports.addProperty(packageName, "npm:$packageName@$version")

--- a/gradle-plugin/src/main/kotlin/io/github/manriif/supabase/functions/task/Tasks.kt
+++ b/gradle-plugin/src/main/kotlin/io/github/manriif/supabase/functions/task/Tasks.kt
@@ -25,6 +25,7 @@ import io.github.manriif.supabase.functions.IMPORT_MAP_TEMPLATE_FILE_NAME
 import io.github.manriif.supabase.functions.KOTLIN_MAIN_FUNCTION_NAME
 import io.github.manriif.supabase.functions.REQUEST_CONFIG_FILE_NAME
 import io.github.manriif.supabase.functions.SUPABASE_FUNCTION_OUTPUT_DIR
+import io.github.manriif.supabase.functions.SUPABASE_FUNCTION_PLUGIN_NAME
 import io.github.manriif.supabase.functions.SUPABASE_FUNCTION_TASK_GROUP
 import io.github.manriif.supabase.functions.SupabaseFunctionExtension
 import io.github.manriif.supabase.functions.kmp.JsDependency
@@ -167,10 +168,18 @@ private fun Project.registerCopyKotlinTask(
     val compileSyncTaskName = "js${uppercaseEnvironment}LibraryCompileSync"
 
     if (tasks.names.none { it == compileSyncTaskName }) {
-        error(
-            "Could not locate task `$compileSyncTaskName`, " +
-                    "be sure you add `binaries.library()` to the js node target."
+        logger.error(
+            """
+            Could not locate task `$compileSyncTaskName`, common reasons for this error are:
+
+            - The `$SUPABASE_FUNCTION_PLUGIN_NAME` plugin was applied on a build script where the kotlin multiplatform plugin was not applied (e.g., root build script)
+            - The kotlin multiplatform plugin was not applied on this project
+            - JS target was not initialized on this project
+            - JS target is missing `binaries.library()`
+            """.trimIndent()
         )
+
+        error("Could not locate task `$compileSyncTaskName`, check the logs for possible causes.")
     }
 
     val taskName = TASK_GENERATE_ENVIRONMENT_TEMPLATE.format(uppercaseEnvironment)

--- a/gradle-plugin/src/main/kotlin/io/github/manriif/supabase/functions/task/Tasks.kt
+++ b/gradle-plugin/src/main/kotlin/io/github/manriif/supabase/functions/task/Tasks.kt
@@ -21,6 +21,7 @@
  */
 package io.github.manriif.supabase.functions.task
 
+import io.github.manriif.supabase.functions.IMPORT_MAP_TEMPLATE_FILE_NAME
 import io.github.manriif.supabase.functions.KOTLIN_MAIN_FUNCTION_NAME
 import io.github.manriif.supabase.functions.REQUEST_CONFIG_FILE_NAME
 import io.github.manriif.supabase.functions.SUPABASE_FUNCTION_OUTPUT_DIR
@@ -93,8 +94,15 @@ private fun Project.registerAggregateImportMapTask(extension: SupabaseFunctionEx
         group = SUPABASE_FUNCTION_TASK_GROUP
         description = "Aggregate functions import maps."
 
-        importMapsDir.convention(layout.buildDirectory.dir("${SUPABASE_FUNCTION_OUTPUT_DIR}/importMaps"))
         supabaseDir.convention(extension.supabaseDir)
+
+        importMapsDir.convention(
+            layout.buildDirectory.dir("${SUPABASE_FUNCTION_OUTPUT_DIR}/importMaps")
+        )
+
+        importMapTemplateFile.convention(
+            extension.supabaseDir.file("functions/$IMPORT_MAP_TEMPLATE_FILE_NAME").orNone()
+        )
     }
 
     tasks.named(PREPARE_KOTLIN_BUILD_SCRIPT_MODEL_TASK) {

--- a/gradle-plugin/src/main/kotlin/io/github/manriif/supabase/functions/util/Error.kt
+++ b/gradle-plugin/src/main/kotlin/io/github/manriif/supabase/functions/util/Error.kt
@@ -1,0 +1,13 @@
+package io.github.manriif.supabase.functions.util
+
+import org.gradle.api.Project
+import org.gradle.api.Task
+import org.gradle.kotlin.dsl.withType
+
+internal inline fun <reified T : Task> Project.postponeErrorOnTaskInvocation(errorMessage: String) {
+    tasks.withType<T>().configureEach {
+        doFirst {
+            error(errorMessage)
+        }
+    }
+}

--- a/gradle-plugin/src/main/kotlin/io/github/manriif/supabase/functions/util/Files.kt
+++ b/gradle-plugin/src/main/kotlin/io/github/manriif/supabase/functions/util/Files.kt
@@ -22,13 +22,13 @@
 package io.github.manriif.supabase.functions.util
 
 import org.gradle.api.Project
-import org.gradle.api.file.RegularFile
+import org.gradle.api.file.FileSystemLocation
 import org.gradle.api.provider.Provider
 
 /**
  * Returns a [Provider] that will provides the file ony if it exists.
  */
-internal fun Provider<RegularFile>.orNone(): Provider<RegularFile> {
+internal fun <T : FileSystemLocation> Provider<T>.orNone(): Provider<T> {
     @Suppress("UnstableApiUsage")
     return filter { it.asFile.exists() }
 }
@@ -36,6 +36,6 @@ internal fun Provider<RegularFile>.orNone(): Provider<RegularFile> {
 /**
  * Returns a [Provider] that will provides the file ony if it exists.
  */
-internal fun RegularFile.orNone(project: Project): Provider<RegularFile> {
+internal fun <T : FileSystemLocation> T.orNone(project: Project): Provider<T> {
     return project.provider { this }.orNone()
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 
 # Projct version
-supabase-functions = "0.0.3"
+supabase-functions = "0.0.4"
 
 jvm-target = "11"
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 
 # Projct version
-supabase-functions = "0.0.2"
+supabase-functions = "0.0.3"
 
 jvm-target = "11"
 


### PR DESCRIPTION
## What kind of change does this PR introduce?
Bug fix (#8)
Bug fix (#6)

## What is the current behavior?
Kotlin multiplatform extension is checked too early and exception are thrown leading the build to fail at sync.

## What is the new behavior?
Kotlin multiplatform extension is checked after project is evaluated. Any incompatibility with the plugin is now reported at task execution time as a warning or error, allowing project to sync and a progressive build script configuration.