### PR TITLE
Resolve JS project dependencies after the project is evaluated

### DIFF
--- a/gradle-plugin/src/main/kotlin/io/github/manriif/supabase/functions/kmp/JsDependency.kt
+++ b/gradle-plugin/src/main/kotlin/io/github/manriif/supabase/functions/kmp/JsDependency.kt
@@ -58,7 +58,11 @@ internal abstract class JsDependency @Inject constructor() {
 
 internal fun Project.jsDependencies(): Provider<Collection<JsDependency>> {
     val projectDependencies = mutableMapOf<String, JsDependency>()
-    findProjectDependencies(projectDependencies)
+
+    afterEvaluate {
+        findProjectDependencies(projectDependencies)
+    }
+
     return provider(projectDependencies::values)
 }
 
@@ -100,8 +104,8 @@ private fun Project.configureJsDependency(collector: MutableMap<String, JsDepend
 private fun Project.findProjectDependencies(collector: MutableMap<String, JsDependency>) {
     configureJsDependency(collector)
 
-    configurations.configureEach {
-        allDependencies.withType<ProjectDependency> {
+    configurations.forEach { configuration ->
+        configuration.allDependencies.withType<ProjectDependency> {
             dependencyProject.findProjectDependencies(collector)
         }
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 
 # Projct version
-supabase-functions = "0.0.4"
+supabase-functions = "0.0.5"
 
 jvm-target = "11"
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix (https://github.com/manriif/supabase-edge-functions-kt/issues/10)

## What is the current behavior?

Project fails to build when the project or a dependant project declare a Kotlin target other than JS.

## What is the new behavior?

Project build successfully.
